### PR TITLE
Scan on Single Repo

### DIFF
--- a/src/main/scala/com/whirlylabs/actionattack/Main.scala
+++ b/src/main/scala/com/whirlylabs/actionattack/Main.scala
@@ -39,6 +39,21 @@ object Main {
           .action((x, c) => c.copy(ghToken = Option(x)))
       )
 
+    cmd("scan")
+      .text("Scans the provided GitHub repository for potentially vulnerable workflows")
+      .action((_, c) => c.copy(mode = OperatingMode.Scan))
+      .children(
+        opt[String]("owner")
+          .text("The owner of the repository")
+          .action((x, c) => c.copy(owner = Option(x))),
+        opt[String]("repo")
+          .text("The name of the repository")
+          .action((x, c) => c.copy(repo = Option(x))),
+        opt[String]("commitHash")
+          .text("The commit hash to scan")
+          .action((x, c) => c.copy(commitSha = Option(x)))
+      )
+
     cmd("review")
       .text("Presents findings of potentially vulnerable applications for manual review")
       .action((_, c) => c.copy(mode = OperatingMode.Review))

--- a/src/main/scala/com/whirlylabs/actionattack/queries/CommitQueries.scala
+++ b/src/main/scala/com/whirlylabs/actionattack/queries/CommitQueries.scala
@@ -62,6 +62,13 @@ trait CommitQueries {
     }
   }
 
+  def getCommitFromSha(commitSha: String): Option[Commit] = {
+    Using.resource(connection.prepareStatement("SELECT * FROM commits WHERE sha = ?")) { stmt =>
+      stmt.setString(1, commitSha)
+      Using.resource(stmt.executeQuery())(Commit.fromResultSet).headOption
+    }
+  }
+
   /** @return
     *   all commits linked to validated and vulnerable findings for the given repository.
     */

--- a/src/main/scala/com/whirlylabs/actionattack/ui/Application.scala
+++ b/src/main/scala/com/whirlylabs/actionattack/ui/Application.scala
@@ -70,7 +70,6 @@ case class Application(
 }
 
 object Application {
-  private val logger = LoggerFactory.getLogger(getClass)
 
   def apply(
     title: String,


### PR DESCRIPTION
Added `scan` command to scan a single repository. Mimics the flow of the Scanner that is left running in the background in the `monitor` process.

Sample command:
```sh
./action-attack scan --owner="Significant-Gravitas" --repo="AutoGPT" --commitHash="ce33e238a964ebe1827a29c4bea1cba271c39a34" -o "db.sqlite3"
```